### PR TITLE
Add logging interceptor and change log module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -45,6 +45,7 @@ import { StatesModule } from './states/states.module';
 import { CitiesModule } from './cities/cities.module';
 
 import { SpecialistsModule } from './specialists/specialists.module';
+import { ChangeLogsModule } from './change-logs/change-logs.module';
 
 @Module({
   imports: [
@@ -94,6 +95,7 @@ import { SpecialistsModule } from './specialists/specialists.module';
     HomeModule,
     CitiesModule,
     StatesModule,
+    ChangeLogsModule,
   ],
 })
 export class AppModule {}

--- a/src/change-logs/change-logs.module.ts
+++ b/src/change-logs/change-logs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ChangeLogsService } from './change-logs.service';
+import { RelationalChangeLogPersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
+
+@Module({
+  imports: [RelationalChangeLogPersistenceModule],
+  providers: [ChangeLogsService],
+  exports: [ChangeLogsService, RelationalChangeLogPersistenceModule],
+})
+export class ChangeLogsModule {}

--- a/src/change-logs/change-logs.service.ts
+++ b/src/change-logs/change-logs.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { ChangeLog } from './domain/change-log';
+import { ChangeLogRepository } from './domain/change-log.repository';
+
+@Injectable()
+export class ChangeLogsService {
+  constructor(private readonly repository: ChangeLogRepository) {}
+
+  create(data: Omit<ChangeLog, 'id' | 'createdAt'>): Promise<ChangeLog> {
+    return this.repository.create(data);
+  }
+}

--- a/src/change-logs/domain/change-log.repository.ts
+++ b/src/change-logs/domain/change-log.repository.ts
@@ -1,0 +1,7 @@
+import { ChangeLog } from './change-log';
+
+export abstract class ChangeLogRepository {
+  abstract create(
+    data: Omit<ChangeLog, 'id' | 'createdAt'>,
+  ): Promise<ChangeLog>;
+}

--- a/src/change-logs/domain/change-log.ts
+++ b/src/change-logs/domain/change-log.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChangeLog {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  tableName: string;
+
+  @ApiProperty()
+  action: string;
+
+  @ApiProperty({ required: false, type: Object, nullable: true })
+  oldValue: Record<string, unknown> | null;
+
+  @ApiProperty({ required: false, type: Object, nullable: true })
+  newValue: Record<string, unknown> | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  changedBy: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  approvedBy: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+}

--- a/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
+++ b/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { EntityRelationalHelper } from '../../../../../utils/relational-entity-helper';
+
+@Entity({ name: 'change_log' })
+export class ChangeLogEntity extends EntityRelationalHelper {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  tableName: string;
+
+  @Column()
+  action: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  oldValue: Record<string, unknown> | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  newValue: Record<string, unknown> | null;
+
+  @Column({ nullable: true })
+  changedBy: string;
+
+  @Column({ nullable: true })
+  approvedBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/change-logs/infrastructure/persistence/relational/relational-persistence.module.ts
+++ b/src/change-logs/infrastructure/persistence/relational/relational-persistence.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChangeLogEntity } from './entities/change-log.entity';
+import { ChangeLogRepository } from '../../../domain/change-log.repository';
+import { ChangeLogRelationalRepository } from './repositories/change-log.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ChangeLogEntity])],
+  providers: [
+    {
+      provide: ChangeLogRepository,
+      useClass: ChangeLogRelationalRepository,
+    },
+  ],
+  exports: [ChangeLogRepository],
+})
+export class RelationalChangeLogPersistenceModule {}

--- a/src/change-logs/infrastructure/persistence/relational/repositories/change-log.repository.ts
+++ b/src/change-logs/infrastructure/persistence/relational/repositories/change-log.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChangeLogRepository } from '../../../../domain/change-log.repository';
+import { ChangeLog } from '../../../../domain/change-log';
+import { ChangeLogEntity } from '../entities/change-log.entity';
+
+@Injectable()
+export class ChangeLogRelationalRepository implements ChangeLogRepository {
+  constructor(
+    @InjectRepository(ChangeLogEntity)
+    private readonly repository: Repository<ChangeLogEntity>,
+  ) {}
+
+  async create(data: Omit<ChangeLog, 'id' | 'createdAt'>): Promise<ChangeLog> {
+    const entity = this.repository.create(data);
+    const saved = await this.repository.save(entity);
+    return saved;
+  }
+}

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -1,0 +1,35 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger('HTTP');
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const { method, url } = request;
+    const now = Date.now();
+
+    return next.handle().pipe(
+      tap(() => {
+        const response = context.switchToHttp().getResponse();
+        this.logger.log(
+          `${method} ${url} ${response.statusCode} +${Date.now() - now}ms`,
+        );
+      }),
+      catchError((err) => {
+        this.logger.error(
+          `${method} ${url} ${err.status || 500} - ${err.message}`,
+        );
+        throw err;
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { AppModule } from './app.module';
 import validationOptions from './utils/validation-options';
 import { AllConfigType } from './config/config.type';
 import { ResolvePromisesInterceptor } from './utils/serializer.interceptor';
+import { LoggingInterceptor } from './interceptors/logging.interceptor';
 import helmet from 'helmet';
 
 async function bootstrap() {
@@ -31,6 +32,7 @@ async function bootstrap() {
   });
   app.useGlobalPipes(new ValidationPipe(validationOptions));
   app.useGlobalInterceptors(
+    new LoggingInterceptor(),
     // ResolvePromisesInterceptor is used to resolve promises in responses because class-transformer can't do it
     // https://github.com/typestack/class-transformer/issues/549
     new ResolvePromisesInterceptor(),


### PR DESCRIPTION
## Summary
- implement `LoggingInterceptor` to log all HTTP requests
- register `LoggingInterceptor` globally
- create `ChangeLogsModule` with relational persistence
- add `change_log` entity and service
- load `ChangeLogsModule` in `AppModule`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68685476d13c83339cc794dc8b653e8d