### PR TITLE
Fix/change log

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,8 +57,6 @@ The main reason for using Hexagonal Architecture is to separate the business log
 
 `[DOMAIN ENTITY].ts` represents an entity used in the business logic. Domain entity has no dependencies on the database or any other infrastructure.
 
-`[SCHEMA].ts` represents the **database structure**. It is used in the document-oriented database (MongoDB).
-
 `[ENTITY].ts` represents the **database structure**. It is used in the relational database (PostgreSQL).
 
 `[MAPPER].ts` is a mapper that converts **database entity** to **domain entity** and vice versa.

--- a/docs/database.md
+++ b/docs/database.md
@@ -23,7 +23,7 @@
 
 ## About databases
 
-Boilerplate supports two types of databases: PostgreSQL with TypeORM and MongoDB with Mongoose. You can choose one of them or use both in your project. The choice of database depends on the requirements of your project.
+The Museum API supports two types of databases: PostgreSQL with TypeORM. You can choose one of them or use both in your project. The choice of database depends on the requirements of your project.
 
 For support of both databases used [Hexagonal Architecture](architecture.md#hexagonal-architecture).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ Frontend (React, Next.js): <https://github.com/dunseen/museum-app>
 
 ## Features
 
-- [x] Database. Support [TypeORM](https://www.npmjs.com/package/typeorm) and [Mongoose](https://www.npmjs.com/package/mongoose).
+- [x] Database. Support [TypeORM](https://www.npmjs.com/package/typeorm).
 - [x] Seeding.
 - [x] Config Service ([@nestjs/config](https://www.npmjs.com/package/@nestjs/config)).
 - [x] Mailing ([nodemailer](https://www.npmjs.com/package/nodemailer)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nestjs-boilerplate",
+  "name": "museum-api",
   "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nestjs-boilerplate",
+      "name": "museum-api",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {

--- a/src/change-logs/domain/change-log.ts
+++ b/src/change-logs/domain/change-log.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from '../../users/domain/user';
 
 export class ChangeLog {
   @ApiProperty()
@@ -16,11 +17,11 @@ export class ChangeLog {
   @ApiProperty({ required: false, type: Object, nullable: true })
   newValue: Record<string, unknown> | null;
 
-  @ApiProperty({ required: false, nullable: true })
-  changedBy: string | null;
+  @ApiProperty({ type: User })
+  changedBy: User;
 
-  @ApiProperty({ required: false, nullable: true })
-  approvedBy: string | null;
+  @ApiProperty({ type: User })
+  approvedBy: User;
 
   @ApiProperty()
   createdAt: Date;

--- a/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
+++ b/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
@@ -2,9 +2,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { EntityRelationalHelper } from '../../../../../utils/relational-entity-helper';
+import { UserEntity } from '../../../../../users/infrastructure/persistence/relational/entities/user.entity';
 
 @Entity({ name: 'change_log' })
 export class ChangeLogEntity extends EntityRelationalHelper {
@@ -23,11 +26,17 @@ export class ChangeLogEntity extends EntityRelationalHelper {
   @Column({ type: 'jsonb', nullable: true })
   newValue: Record<string, unknown> | null;
 
-  @Column({ nullable: true })
-  changedBy: string;
+  @ManyToOne(() => UserEntity, {
+    eager: true,
+  })
+  @Index()
+  changedBy: UserEntity;
 
-  @Column({ nullable: true })
-  approvedBy: string;
+  @ManyToOne(() => UserEntity, {
+    eager: true,
+  })
+  @Index()
+  approvedBy: UserEntity;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/change-logs/infrastructure/persistence/relational/mappers/change-log.mapper.ts
+++ b/src/change-logs/infrastructure/persistence/relational/mappers/change-log.mapper.ts
@@ -1,0 +1,38 @@
+import { ChangeLog } from '../../../../domain/change-log';
+import { ChangeLogEntity } from '../entities/change-log.entity';
+import { UserMapper } from '../../../../../users/infrastructure/persistence/relational/mappers/user.mapper';
+
+export class ChangeLogMapper {
+  static toDomain(raw: ChangeLogEntity): ChangeLog {
+    const domain = new ChangeLog();
+    domain.id = raw.id;
+    domain.tableName = raw.tableName;
+    domain.action = raw.action;
+    domain.oldValue = raw.oldValue;
+    domain.newValue = raw.newValue;
+    domain.changedBy = UserMapper.toDomain(raw.changedBy);
+    domain.approvedBy = UserMapper.toDomain(raw.approvedBy);
+    domain.createdAt = raw.createdAt;
+
+    return domain;
+  }
+
+  static toPersistence(domain: Partial<ChangeLog>): ChangeLogEntity {
+    const entity = new ChangeLogEntity();
+    if (domain.id) entity.id = domain.id;
+
+    entity.tableName = domain.tableName ?? '';
+    entity.action = domain.action ?? '';
+    entity.oldValue = domain.oldValue ?? null;
+    entity.newValue = domain.newValue ?? null;
+
+    if (domain.changedBy)
+      entity.changedBy = UserMapper.toPersistence(domain.changedBy);
+
+    if (domain.approvedBy)
+      entity.approvedBy = UserMapper.toPersistence(domain.approvedBy);
+
+    if (domain.createdAt) entity.createdAt = domain.createdAt;
+    return entity;
+  }
+}

--- a/src/change-logs/infrastructure/persistence/relational/repositories/change-log.repository.ts
+++ b/src/change-logs/infrastructure/persistence/relational/repositories/change-log.repository.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { ChangeLogRepository } from '../../../../domain/change-log.repository';
 import { ChangeLog } from '../../../../domain/change-log';
 import { ChangeLogEntity } from '../entities/change-log.entity';
+import { ChangeLogMapper } from '../mappers/change-log.mapper';
 
 @Injectable()
 export class ChangeLogRelationalRepository implements ChangeLogRepository {
@@ -13,7 +14,7 @@ export class ChangeLogRelationalRepository implements ChangeLogRepository {
   ) {}
 
   async create(data: Omit<ChangeLog, 'id' | 'createdAt'>): Promise<ChangeLog> {
-    const entity = this.repository.create(data);
+    const entity = this.repository.create(ChangeLogMapper.toPersistence(data));
     const saved = await this.repository.save(entity);
     return saved;
   }

--- a/src/database/config/database-config.type.ts
+++ b/src/database/config/database-config.type.ts
@@ -1,5 +1,4 @@
 export type DatabaseConfig = {
-  isDocumentDatabase: boolean;
   url?: string;
   type?: string;
   host?: string;

--- a/src/database/config/database.config.ts
+++ b/src/database/config/database.config.ts
@@ -19,10 +19,6 @@ class EnvironmentVariablesValidator {
 
   @ValidateIf((envValues) => !envValues.DATABASE_URL)
   @IsString()
-  DATABASE_TYPE: string;
-
-  @ValidateIf((envValues) => !envValues.DATABASE_URL)
-  @IsString()
   DATABASE_HOST: string;
 
   @ValidateIf((envValues) => !envValues.DATABASE_URL)
@@ -84,7 +80,6 @@ export default registerAs<DatabaseConfig>('database', () => {
   validateConfig(process.env, EnvironmentVariablesValidator);
 
   return {
-    isDocumentDatabase: ['mongodb'].includes(process.env.DATABASE_TYPE ?? ''),
     url: process.env.DATABASE_URL,
     type: process.env.DATABASE_TYPE,
     host: process.env.DATABASE_HOST,

--- a/src/database/migrations/1751669951822-migrations.ts
+++ b/src/database/migrations/1751669951822-migrations.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1751669951822 implements MigrationInterface {
+  name = 'Migrations1751669951822';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "change_log" ("id" SERIAL NOT NULL, "tableName" character varying NOT NULL, "action" character varying NOT NULL, "oldValue" jsonb, "newValue" jsonb, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "changedById" uuid, "approvedById" uuid, CONSTRAINT "PK_d00462cfb97b72c95357d559136" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d339722079391abbc649608412" ON "change_log" ("changedById") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_95c6e2d5484ae3244f063d5ecb" ON "change_log" ("approvedById") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "change_log" ADD CONSTRAINT "FK_d339722079391abbc649608412a" FOREIGN KEY ("changedById") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "change_log" ADD CONSTRAINT "FK_95c6e2d5484ae3244f063d5ecb3" FOREIGN KEY ("approvedById") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "change_log" DROP CONSTRAINT "FK_95c6e2d5484ae3244f063d5ecb3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "change_log" DROP CONSTRAINT "FK_d339722079391abbc649608412a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_95c6e2d5484ae3244f063d5ecb"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d339722079391abbc649608412"`,
+    );
+    await queryRunner.query(`DROP TABLE "change_log"`);
+  }
+}


### PR DESCRIPTION
This pull request introduces several changes to the codebase, primarily focusing on enhancing the `ChangeLog` functionality by integrating user references, removing MongoDB-related configurations, and updating documentation to reflect these changes. Below is a summary of the most critical updates.

### Enhancements to `ChangeLog` functionality:
* Updated `src/change-logs/domain/change-log.ts` to replace `changedBy` and `approvedBy` fields from `string | null` to `User` type, enabling direct references to user entities.
* Modified `src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts` to use `@ManyToOne` relationships for `changedBy` and `approvedBy`, linking them to `UserEntity`. Added indexes for these fields.
* Added `ChangeLogMapper` in `src/change-logs/infrastructure/persistence/relational/mappers/change-log.mapper.ts` to handle conversion between domain and persistence models.
* Updated `src/change-logs/infrastructure/persistence/relational/repositories/change-log.repository.ts` to use the new `ChangeLogMapper` for creating database entities.
* Introduced a migration script in `src/database/migrations/1751669951822-migrations.ts` to create the `change_log` table with foreign key constraints linking `changedBy` and `approvedBy` to the `user` table.

### Removal of MongoDB-related configurations:
* Removed the `isDocumentDatabase` field from `src/database/config/database-config.type.ts` and associated logic from `src/database/config/database.config.ts`. [[1]](diffhunk://#diff-79087233eeb82ce543a2131d6d96ee12e78a7f0ee80ad1a82c74a394a11d34c4L2) [[2]](diffhunk://#diff-586912ed4c065851e406cfe9623117763168eb63500fe1a896fb5e2df53458d4L87)
* Updated environment variable validation in `src/database/config/database.config.ts` by removing checks for MongoDB-specific fields such as `DATABASE_TYPE`.

### Updates to documentation:
* Revised `docs/architecture.md` to remove references to MongoDB schemas and clarify the use of PostgreSQL for database structure.
* Updated `docs/database.md` to reflect that only PostgreSQL is supported, removing mentions of MongoDB.
* Adjusted `docs/introduction.md` to remove MongoDB from the list of supported databases.