### PR TITLE
Add migration and remove approvedBy field

### DIFF
--- a/src/change-logs/domain/change-log.ts
+++ b/src/change-logs/domain/change-log.ts
@@ -12,16 +12,13 @@ export class ChangeLog {
   action: string;
 
   @ApiProperty({ required: false, type: Object, nullable: true })
-  oldValue: Record<string, unknown> | null;
+  oldValue: unknown | null;
 
   @ApiProperty({ required: false, type: Object, nullable: true })
-  newValue: Record<string, unknown> | null;
+  newValue: unknown | null;
 
   @ApiProperty({ type: User })
   changedBy: User;
-
-  @ApiProperty({ type: User })
-  approvedBy: User;
 
   @ApiProperty()
   createdAt: Date;

--- a/src/change-logs/domain/change-log.ts
+++ b/src/change-logs/domain/change-log.ts
@@ -12,10 +12,10 @@ export class ChangeLog {
   action: string;
 
   @ApiProperty({ required: false, type: Object, nullable: true })
-  oldValue: unknown | null;
+  oldValue: unknown;
 
   @ApiProperty({ required: false, type: Object, nullable: true })
-  newValue: unknown | null;
+  newValue: unknown;
 
   @ApiProperty({ type: User })
   changedBy: User;

--- a/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
+++ b/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
@@ -21,10 +21,10 @@ export class ChangeLogEntity extends EntityRelationalHelper {
   action: string;
 
   @Column({ type: 'jsonb', nullable: true })
-  oldValue: Record<string, unknown> | null;
+  oldValue: unknown | null;
 
   @Column({ type: 'jsonb', nullable: true })
-  newValue: Record<string, unknown> | null;
+  newValue: unknown | null;
 
   @ManyToOne(() => UserEntity, {
     eager: true,
@@ -32,11 +32,6 @@ export class ChangeLogEntity extends EntityRelationalHelper {
   @Index()
   changedBy: UserEntity;
 
-  @ManyToOne(() => UserEntity, {
-    eager: true,
-  })
-  @Index()
-  approvedBy: UserEntity;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
+++ b/src/change-logs/infrastructure/persistence/relational/entities/change-log.entity.ts
@@ -21,17 +21,16 @@ export class ChangeLogEntity extends EntityRelationalHelper {
   action: string;
 
   @Column({ type: 'jsonb', nullable: true })
-  oldValue: unknown | null;
+  oldValue: unknown;
 
   @Column({ type: 'jsonb', nullable: true })
-  newValue: unknown | null;
+  newValue: unknown;
 
   @ManyToOne(() => UserEntity, {
     eager: true,
   })
   @Index()
   changedBy: UserEntity;
-
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/change-logs/infrastructure/persistence/relational/mappers/change-log.mapper.ts
+++ b/src/change-logs/infrastructure/persistence/relational/mappers/change-log.mapper.ts
@@ -11,7 +11,6 @@ export class ChangeLogMapper {
     domain.oldValue = raw.oldValue;
     domain.newValue = raw.newValue;
     domain.changedBy = UserMapper.toDomain(raw.changedBy);
-    domain.approvedBy = UserMapper.toDomain(raw.approvedBy);
     domain.createdAt = raw.createdAt;
 
     return domain;
@@ -28,9 +27,6 @@ export class ChangeLogMapper {
 
     if (domain.changedBy)
       entity.changedBy = UserMapper.toPersistence(domain.changedBy);
-
-    if (domain.approvedBy)
-      entity.approvedBy = UserMapper.toPersistence(domain.approvedBy);
 
     if (domain.createdAt) entity.createdAt = domain.createdAt;
     return entity;

--- a/src/database/migrations/1751672705534-remove-approved-by-from-change-log.ts
+++ b/src/database/migrations/1751672705534-remove-approved-by-from-change-log.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveApprovedByFromChangeLog1751672705534 implements MigrationInterface {
+  name = 'RemoveApprovedByFromChangeLog1751672705534';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "change_log" DROP CONSTRAINT "FK_95c6e2d5484ae3244f063d5ecb3"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_95c6e2d5484ae3244f063d5ecb"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "change_log" DROP COLUMN "approvedById"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "change_log" ADD "approvedById" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_95c6e2d5484ae3244f063d5ecb" ON "change_log" ("approvedById") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "change_log" ADD CONSTRAINT "FK_95c6e2d5484ae3244f063d5ecb3" FOREIGN KEY ("approvedById") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/database/migrations/1751672705534-remove-approved-by-from-change-log.ts
+++ b/src/database/migrations/1751672705534-remove-approved-by-from-change-log.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class RemoveApprovedByFromChangeLog1751672705534 implements MigrationInterface {
+export class RemoveApprovedByFromChangeLog1751672705534
+  implements MigrationInterface
+{
   name = 'RemoveApprovedByFromChangeLog1751672705534';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
@@ -16,9 +18,7 @@ export class RemoveApprovedByFromChangeLog1751672705534 implements MigrationInte
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "change_log" ADD "approvedById" uuid`,
-    );
+    await queryRunner.query(`ALTER TABLE "change_log" ADD "approvedById" uuid`);
     await queryRunner.query(
       `CREATE INDEX "IDX_95c6e2d5484ae3244f063d5ecb" ON "change_log" ("approvedById") `,
     );

--- a/src/modules/dashboard/dashboard-posts.controller.ts
+++ b/src/modules/dashboard/dashboard-posts.controller.ts
@@ -132,7 +132,7 @@ export class DashboardPostsController {
     type: String,
     required: true,
   })
-  remove(@Param('id') id: string) {
-    return this.deletePostUseCase.execute(id);
+  remove(@Param('id') id: string, @JwtPayload() payload: JwtPayloadType) {
+    return this.deletePostUseCase.execute(id, payload);
   }
 }

--- a/src/modules/dashboard/dashboard-species.controller.ts
+++ b/src/modules/dashboard/dashboard-species.controller.ts
@@ -131,10 +131,7 @@ export class DashboardSpeciesController {
     type: Number,
     required: true,
   })
-  remove(
-    @Param('id') id: number,
-    @JwtPayload() payload: JwtPayloadType,
-  ) {
+  remove(@Param('id') id: number, @JwtPayload() payload: JwtPayloadType) {
     return this.speciesService.remove(id, payload);
   }
 }

--- a/src/modules/dashboard/dashboard-species.controller.ts
+++ b/src/modules/dashboard/dashboard-species.controller.ts
@@ -131,7 +131,10 @@ export class DashboardSpeciesController {
     type: Number,
     required: true,
   })
-  remove(@Param('id') id: number) {
-    return this.speciesService.remove(id);
+  remove(
+    @Param('id') id: number,
+    @JwtPayload() payload: JwtPayloadType,
+  ) {
+    return this.speciesService.remove(id, payload);
   }
 }

--- a/src/modules/dashboard/dashboard-taxons.controller.ts
+++ b/src/modules/dashboard/dashboard-taxons.controller.ts
@@ -118,10 +118,7 @@ export class DashboardTaxonsController {
     type: String,
     required: true,
   })
-  remove(
-    @Param('id') id: string,
-    @JwtPayload() payload: JwtPayloadType,
-  ) {
+  remove(@Param('id') id: string, @JwtPayload() payload: JwtPayloadType) {
     return this.taxonsService.remove(Number(id), payload);
   }
 }

--- a/src/modules/dashboard/dashboard-taxons.controller.ts
+++ b/src/modules/dashboard/dashboard-taxons.controller.ts
@@ -32,6 +32,8 @@ import {
 } from '../../utils/dto/infinity-pagination-response.dto';
 import { infinityPagination } from '../../utils/infinity-pagination';
 import { GetTaxonDto } from '../../taxons/dto/get-taxon.dto';
+import { JwtPayload } from '../../auth/strategies/jwt.decorator';
+import { JwtPayloadType } from '../../auth/strategies/types/jwt-payload.type';
 
 @ApiTags('Dashboard - Taxons')
 @ApiBearerAuth()
@@ -48,8 +50,11 @@ export class DashboardTaxonsController {
   @ApiCreatedResponse({
     type: Taxon,
   })
-  create(@Body() createTaxonDto: CreateTaxonDto) {
-    return this.taxonsService.create(createTaxonDto);
+  create(
+    @Body() createTaxonDto: CreateTaxonDto,
+    @JwtPayload() payload: JwtPayloadType,
+  ) {
+    return this.taxonsService.create(createTaxonDto, payload);
   }
 
   @Get()
@@ -99,8 +104,12 @@ export class DashboardTaxonsController {
   @ApiOkResponse({
     type: Taxon,
   })
-  update(@Param('id') id: string, @Body() updateTaxonDto: UpdateTaxonDto) {
-    return this.taxonsService.update(Number(id), updateTaxonDto);
+  update(
+    @Param('id') id: string,
+    @Body() updateTaxonDto: UpdateTaxonDto,
+    @JwtPayload() payload: JwtPayloadType,
+  ) {
+    return this.taxonsService.update(Number(id), updateTaxonDto, payload);
   }
 
   @Delete(':id')
@@ -109,7 +118,10 @@ export class DashboardTaxonsController {
     type: String,
     required: true,
   })
-  remove(@Param('id') id: string) {
-    return this.taxonsService.remove(Number(id));
+  remove(
+    @Param('id') id: string,
+    @JwtPayload() payload: JwtPayloadType,
+  ) {
+    return this.taxonsService.remove(Number(id), payload);
   }
 }

--- a/src/modules/dashboard/dashboard-users.controller.ts
+++ b/src/modules/dashboard/dashboard-users.controller.ts
@@ -25,6 +25,8 @@ import { Roles } from '../../roles/roles.decorator';
 import { RoleEnum } from '../../roles/roles.enum';
 import { RolesGuard } from '../../roles/roles.guard';
 import { User } from '../../users/domain/user';
+import { JwtPayload } from '../../auth/strategies/jwt.decorator';
+import { JwtPayloadType } from '../../auth/strategies/types/jwt-payload.type';
 import { CreateUserDto } from '../../users/dto/create-user.dto';
 import { QueryUserDto } from '../../users/dto/query-user.dto';
 import { UpdateUserDto } from '../../users/dto/update-user.dto';
@@ -55,8 +57,11 @@ export class DashboardUsersController {
   })
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  create(@Body() createProfileDto: CreateUserDto): Promise<User> {
-    return this.usersService.create(createProfileDto);
+  create(
+    @Body() createProfileDto: CreateUserDto,
+    @JwtPayload() payload: JwtPayloadType,
+  ): Promise<User> {
+    return this.usersService.create(createProfileDto, payload);
   }
 
   @ApiOkResponse({
@@ -119,8 +124,9 @@ export class DashboardUsersController {
   update(
     @Param('id') id: User['id'],
     @Body() updateProfileDto: UpdateUserDto,
+    @JwtPayload() payload: JwtPayloadType,
   ): Promise<User | null> {
-    return this.usersService.update(id, updateProfileDto);
+    return this.usersService.update(id, updateProfileDto, payload);
   }
 
   @Delete(':id')
@@ -130,7 +136,10 @@ export class DashboardUsersController {
     required: true,
   })
   @HttpCode(HttpStatus.NO_CONTENT)
-  remove(@Param('id') id: User['id']): Promise<void> {
-    return this.usersService.remove(id);
+  remove(
+    @Param('id') id: User['id'],
+    @JwtPayload() payload: JwtPayloadType,
+  ): Promise<void> {
+    return this.usersService.remove(id, payload);
   }
 }

--- a/src/posts/application/use-cases/create-post.use-case.ts
+++ b/src/posts/application/use-cases/create-post.use-case.ts
@@ -2,6 +2,7 @@ import { JwtPayloadType } from '../../../auth/strategies/types/jwt-payload.type'
 import { SpeciesService } from '../../../species/species.service';
 import { UsersService } from '../../../users/users.service';
 import { PostRepository } from '../../domain/post.repository';
+import { ChangeLogsService } from '../../../change-logs/change-logs.service';
 import { Post } from '../../domain/post';
 import { PostStatusEnum } from '../../domain/post-status.enum';
 import { PostFactory } from '../../domain/post.factory';
@@ -22,6 +23,7 @@ export class CreatePostUseCase {
     private readonly userService: UsersService,
     @Inject(forwardRef(() => SpeciesService))
     private readonly speciesService: SpeciesService,
+    private readonly changeLogsService: ChangeLogsService,
   ) {}
 
   async execute(createPostDto: CreatePostDto, payload: JwtPayloadType) {
@@ -51,6 +53,14 @@ export class CreatePostUseCase {
       .build();
 
     const newPost = await this.postRepository.create(post);
+
+    await this.changeLogsService.create({
+      tableName: 'post',
+      action: 'create',
+      oldValue: null,
+      newValue: newPost,
+      changedBy: author,
+    });
 
     return PostFactory.toDto(newPost);
   }

--- a/src/posts/application/use-cases/delete-post.use-case.ts
+++ b/src/posts/application/use-cases/delete-post.use-case.ts
@@ -1,12 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { Post } from '../../domain/post';
 import { PostRepository } from '../../domain/post.repository';
+import { UsersService } from '../../../users/users.service';
+import { JwtPayloadType } from '../../../auth/strategies/types/jwt-payload.type';
+import { ChangeLogsService } from '../../../change-logs/change-logs.service';
 
 @Injectable()
 export class DeletePostUseCase {
-  constructor(private readonly postRepository: PostRepository) {}
+  constructor(
+    private readonly postRepository: PostRepository,
+    private readonly userService: UsersService,
+    private readonly changeLogsService: ChangeLogsService,
+  ) {}
 
-  async execute(id: Post['id']) {
+  async execute(id: Post['id'], payload: JwtPayloadType) {
+    const post = await this.postRepository.findById(id);
     await this.postRepository.remove(id);
+    const changer = await this.userService.ensureUserExists(payload.id);
+    await this.changeLogsService.create({
+      tableName: 'post',
+      action: 'delete',
+      oldValue: post,
+      newValue: null,
+      changedBy: changer,
+    });
   }
 }

--- a/src/posts/application/use-cases/validate-post.use-case.ts
+++ b/src/posts/application/use-cases/validate-post.use-case.ts
@@ -12,6 +12,7 @@ import { PostService } from '../../domain/post.service';
 import { UserNotFoundException } from '../../../users/domain/exceptions/user-not-found.error';
 import { PostNotFoundException } from '../../domain/exceptions/post-not-found.error';
 import { UpdatePostDto } from '../dtos/update-post.dto';
+import { ChangeLogsService } from '../../../change-logs/change-logs.service';
 
 @Injectable()
 export class ValidatePostUseCase {
@@ -19,6 +20,7 @@ export class ValidatePostUseCase {
     private readonly postRepository: PostRepository,
     private readonly userService: UsersService,
     private readonly postService: PostService,
+    private readonly changeLogsService: ChangeLogsService,
   ) {}
 
   async execute(
@@ -52,6 +54,14 @@ export class ValidatePostUseCase {
       }
 
       await this.postRepository.update(id, updatedPost);
+
+      await this.changeLogsService.create({
+        tableName: 'post',
+        action: 'update',
+        oldValue: post,
+        newValue: updatedPost,
+        changedBy: validator,
+      });
     } catch (error) {
       if (error instanceof UserNotFoundException) {
         throw new ForbiddenException(error.message);

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -10,6 +10,7 @@ import { DeletePostUseCase } from './application/use-cases/delete-post.use-case'
 import { UsersModule } from '../users/users.module';
 import { ValidatePostUseCase } from './application/use-cases/validate-post.use-case';
 import { PostsController } from './posts.controller';
+import { ChangeLogsModule } from '../change-logs/change-logs.module';
 import { ListHomePagePostsUseCase } from './application/use-cases/list-home-page-posts.use-case';
 import { FindHomePostDetailsByNameUseCase } from './application/use-cases/find-home-post-details-by-name.use-case';
 
@@ -29,6 +30,7 @@ const providers = [
     RelationalUserPersistenceModule,
     UsersModule,
     forwardRef(() => SpeciesModule),
+    ChangeLogsModule,
   ],
   controllers: [PostsController],
   providers,

--- a/src/species/species.module.ts
+++ b/src/species/species.module.ts
@@ -6,6 +6,8 @@ import { RelationalTaxonPersistenceModule } from '../taxons/infrastructure/persi
 import { RelationalFilePersistenceModule } from '../files/infrastructure/persistence/relational/relational-persistence.module';
 import { FileMinioModule } from '../files/infrastructure/uploader/minio/files.module';
 import { PostsModule } from '../posts/posts.module';
+import { ChangeLogsModule } from '../change-logs/change-logs.module';
+import { UsersModule } from '../users/users.module';
 import { RelationalCityPersistenceModule } from '../cities/infrastructure/persistence/relational/relational-persistence.module';
 import { RelationalStatePersistenceModule } from '../states/infrastructure/persistence/relational/relational-persistence.module';
 import { RelationalSpecialistPersistenceModule } from '../specialists/infrastructure/persistence/relational/relational-persistence.module';
@@ -21,6 +23,8 @@ import { RelationalSpecialistPersistenceModule } from '../specialists/infrastruc
     RelationalSpecialistPersistenceModule,
     FileMinioModule,
     forwardRef(() => PostsModule),
+    ChangeLogsModule,
+    UsersModule,
   ],
   controllers: [],
   providers: [SpeciesService],

--- a/src/taxons/taxons.module.ts
+++ b/src/taxons/taxons.module.ts
@@ -4,12 +4,16 @@ import { TaxonsController } from './taxons.controller';
 import { RelationalTaxonPersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
 import { RelationalHierarchyPersistenceModule } from '../hierarchies/infrastructure/persistence/relational/relational-persistence.module';
 import { RelationalCharacteristicPersistenceModule } from '../characteristics/infrastructure/persistence/relational/relational-persistence.module';
+import { ChangeLogsModule } from '../change-logs/change-logs.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     RelationalTaxonPersistenceModule,
     RelationalHierarchyPersistenceModule,
     RelationalCharacteristicPersistenceModule,
+    UsersModule,
+    ChangeLogsModule,
   ],
   controllers: [TaxonsController],
   providers: [TaxonsService],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ChangeLogsModule } from '../change-logs/change-logs.module';
 
 import { UsersService } from './users.service';
 import { RelationalUserPersistenceModule } from './infrastructure/persistence/relational/relational-persistence.module';
@@ -6,7 +7,7 @@ import { RelationalUserPersistenceModule } from './infrastructure/persistence/re
 const infrastructurePersistenceModule = RelationalUserPersistenceModule;
 
 @Module({
-  imports: [infrastructurePersistenceModule],
+  imports: [infrastructurePersistenceModule, ChangeLogsModule],
   controllers: [],
   providers: [UsersService],
   exports: [UsersService, infrastructurePersistenceModule],


### PR DESCRIPTION
## Summary
- drop `approvedBy` from change log domain and persistence
- adjust service logic to stop storing an approver
- add migration to remove `approvedById` column
- loosen change log old/new value types to avoid casting
- use `unknown` for `oldValue` and `newValue` rather than `any`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6868614f558c8333be43820c305f46f3