### PR TITLE
Improve user registration flow

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -40,6 +40,20 @@ services:
       - ${MINIO_WEB_PORT}:${MINIO_WEB_PORT}
       - ${MINIO_PORT}:${MINIO_PORT}
 
+  maildev:
+    container_name: museum-maildev
+    build:
+      context: .
+      dockerfile: maildev.Dockerfile
+    env_file:
+      - .env
+    networks:
+      - internal
+      - public
+    ports:
+      - ${MAIL_CLIENT_PORT}:${MAIL_CLIENT_PORT}
+      - ${MAIL_PORT}:${MAIL_PORT}
+
   api:
     container_name: museum-api
     build: .

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,7 +19,6 @@ import { AuthConfirmEmailDto } from './dto/auth-confirm-email.dto';
 import { AuthResetPasswordDto } from './dto/auth-reset-password.dto';
 import { AuthUpdateDto } from './dto/auth-update.dto';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthRegisterLoginDto } from './dto/auth-register-login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { NullableType } from '../utils/types/nullable.type';
 import { User } from '../users/domain/user';
@@ -43,12 +42,6 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   public login(@Body() loginDto: AuthEmailLoginDto): Promise<LoginResponseDto> {
     return this.service.validateLogin(loginDto);
-  }
-
-  @Post('email/register')
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async register(@Body() createUserDto: AuthRegisterLoginDto): Promise<void> {
-    await this.service.register(createUserDto);
   }
 
   @Post('email/confirm')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -48,7 +48,7 @@ export class AuthController {
   @Post('email/register')
   @HttpCode(HttpStatus.NO_CONTENT)
   async register(@Body() createUserDto: AuthRegisterLoginDto): Promise<void> {
-    return this.service.register(createUserDto);
+    await this.service.register(createUserDto);
   }
 
   @Post('email/confirm')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -105,7 +105,7 @@ export class AuthService {
         role: dto.role ?? {
           id: RoleEnum.operator,
         },
-        status: dto.status ?? {
+        status: {
           id: StatusEnum.inactive,
         },
       },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -12,7 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import bcrypt from 'bcryptjs';
 import { AuthEmailLoginDto } from './dto/auth-email-login.dto';
 import { AuthUpdateDto } from './dto/auth-update.dto';
-import { AuthRegisterLoginDto } from './dto/auth-register-login.dto';
+import { CreateUserDto } from '../users/dto/create-user.dto';
 import { NullableType } from '../utils/types/nullable.type';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { ConfigService } from '@nestjs/config';
@@ -97,17 +97,20 @@ export class AuthService {
     };
   }
 
-  async register(dto: AuthRegisterLoginDto): Promise<void> {
-    const user = await this.usersService.create({
-      ...dto,
-      email: dto.email,
-      role: {
-        id: RoleEnum.operator,
+  async register(dto: CreateUserDto, payload?: JwtPayloadType): Promise<User> {
+    const user = await this.usersService.create(
+      {
+        ...dto,
+        email: dto.email,
+        role: dto.role ?? {
+          id: RoleEnum.operator,
+        },
+        status: dto.status ?? {
+          id: StatusEnum.inactive,
+        },
       },
-      status: {
-        id: StatusEnum.inactive,
-      },
-    });
+      payload,
+    );
 
     const hash = await this.jwtService.signAsync(
       {
@@ -129,6 +132,8 @@ export class AuthService {
         hash,
       },
     });
+
+    return user;
   }
 
   async confirmEmail(hash: string): Promise<void> {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -30,11 +30,11 @@ import { User } from '../users/domain/user';
 @Injectable()
 export class AuthService {
   constructor(
-    private jwtService: JwtService,
-    private usersService: UsersService,
-    private sessionService: SessionService,
-    private mailService: MailService,
-    private configService: ConfigService<AllConfigType>,
+    private readonly jwtService: JwtService,
+    private readonly usersService: UsersService,
+    private readonly sessionService: SessionService,
+    private readonly mailService: MailService,
+    private readonly configService: ConfigService<AllConfigType>,
   ) {}
 
   async validateLogin(loginDto: AuthEmailLoginDto): Promise<LoginResponseDto> {

--- a/src/auth/dto/auth-register-login.dto.ts
+++ b/src/auth/dto/auth-register-login.dto.ts
@@ -1,7 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength, IsOptional } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { lowerCaseTransformer } from '../../utils/transformers/lower-case.transformer';
+import { RoleDto } from '../../roles/dto/role.dto';
+import { StatusDto } from '../../statuses/dto/status.dto';
 
 export class AuthRegisterLoginDto {
   @ApiProperty({ example: 'test1@example.com', type: String })
@@ -24,4 +26,14 @@ export class AuthRegisterLoginDto {
   @ApiProperty({ example: '+55123456789' })
   @IsNotEmpty()
   phone: string;
+
+  @ApiPropertyOptional({ type: RoleDto })
+  @IsOptional()
+  @Type(() => RoleDto)
+  role?: RoleDto;
+
+  @ApiPropertyOptional({ type: StatusDto })
+  @IsOptional()
+  @Type(() => StatusDto)
+  status?: StatusDto;
 }

--- a/src/modules/dashboard/dashboard-users.controller.ts
+++ b/src/modules/dashboard/dashboard-users.controller.ts
@@ -31,6 +31,7 @@ import { CreateUserDto } from '../../users/dto/create-user.dto';
 import { QueryUserDto } from '../../users/dto/query-user.dto';
 import { UpdateUserDto } from '../../users/dto/update-user.dto';
 import { UsersService } from '../../users/users.service';
+import { AuthService } from '../../auth/auth.service';
 import {
   InfinityPaginationResponse,
   InfinityPaginationResponseDto,
@@ -47,7 +48,10 @@ import { NullableType } from '../../utils/types/nullable.type';
   version: '1',
 })
 export class DashboardUsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
 
   @ApiCreatedResponse({
     type: User,
@@ -61,7 +65,7 @@ export class DashboardUsersController {
     @Body() createProfileDto: CreateUserDto,
     @JwtPayload() payload: JwtPayloadType,
   ): Promise<User> {
-    return this.usersService.create(createProfileDto, payload);
+    return this.authService.register(createProfileDto, payload);
   }
 
   @ApiOkResponse({

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -19,6 +19,7 @@ import { DashboardUsersController } from './dashboard-users.controller';
 import { UsersModule } from '../../users/users.module';
 import { DashboardSpecialistsController } from './dashboard-specialists.controller';
 import { SpecialistsModule } from '../../specialists/specialists.module';
+import { AuthModule } from '../../auth/auth.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SpecialistsModule } from '../../specialists/specialists.module';
     SpeciesModule,
     FileMinioModule,
     UsersModule,
+    AuthModule,
     SpecialistsModule,
   ],
   providers: [ListDashboardSummaryUseCase],

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -16,7 +16,7 @@ export class CreateUserDto {
   @Transform(lowerCaseTransformer)
   @IsNotEmpty()
   @IsEmail()
-  email: string | null;
+  email: string;
 
   @ApiProperty()
   @MinLength(6)
@@ -24,15 +24,15 @@ export class CreateUserDto {
 
   @ApiProperty({ example: 'John', type: String })
   @IsNotEmpty()
-  firstName: string | null;
+  firstName: string;
 
   @ApiProperty({ example: 'Doe', type: String })
   @IsNotEmpty()
-  lastName: string | null;
+  lastName: string;
 
   @ApiProperty({ example: '+551235', type: String })
   @IsNotEmpty()
-  phone: string | null;
+  phone: string;
 
   @ApiPropertyOptional({ type: RoleDto })
   @IsOptional()

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -13,7 +13,7 @@ export class UpdateUserDto extends PartialType(CreateUserDto) {
   @Transform(lowerCaseTransformer)
   @IsOptional()
   @IsEmail()
-  email?: string | null;
+  email?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
@@ -22,15 +22,15 @@ export class UpdateUserDto extends PartialType(CreateUserDto) {
 
   provider?: string;
 
-  socialId?: string | null;
+  socialId?: string;
 
   @ApiPropertyOptional({ example: 'John', type: String })
   @IsOptional()
-  firstName?: string | null;
+  firstName?: string;
 
   @ApiPropertyOptional({ example: 'Doe', type: String })
   @IsOptional()
-  lastName?: string | null;
+  lastName?: string;
 
   @ApiPropertyOptional({ type: () => FileDto })
   @IsOptional()


### PR DESCRIPTION
## Summary
- allow optional role and status when registering
- send confirmation email when admin creates a user
- expose AuthService in dashboard module

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68687024c8188333aa48777b56c3aafc