### PR TITLE
Fix registration status and remove register endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/common": "10.4.16",
         "@nestjs/config": "3.2.3",
         "@nestjs/core": "10.4.1",
+        "@nestjs/event-emitter": "3.0.1",
         "@nestjs/jwt": "10.2.0",
         "@nestjs/passport": "10.0.3",
         "@nestjs/platform-express": "10.4.1",
@@ -4736,6 +4737,19 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.0.1.tgz",
+      "integrity": "sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -10535,6 +10549,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@nestjs/passport": "10.0.3",
     "@nestjs/platform-express": "10.4.1",
     "@nestjs/swagger": "7.4.0",
+    "@nestjs/event-emitter": "3.0.1",
     "@nestjs/typeorm": "10.0.2",
     "@types/multer-s3": "3.0.3",
     "bcryptjs": "2.4.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { UsersModule } from './users/users.module';
 import { FilesModule } from './files/files.module';
 import { AuthModule } from './auth/auth.module';
@@ -55,6 +56,7 @@ import { ChangeLogsModule } from './change-logs/change-logs.module';
       load: [databaseConfig, authConfig, appConfig, mailConfig, fileConfig],
       envFilePath: ['.env'],
     }),
+    EventEmitterModule.forRoot(),
     I18nModule.forRootAsync({
       useFactory: (configService: ConfigService<AllConfigType>) => ({
         fallbackLanguage: configService.getOrThrow('app.fallbackLanguage', {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,7 +19,6 @@ import { AuthConfirmEmailDto } from './dto/auth-confirm-email.dto';
 import { AuthResetPasswordDto } from './dto/auth-reset-password.dto';
 import { AuthUpdateDto } from './dto/auth-update.dto';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthRegisterLoginDto } from './dto/auth-register-login.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { NullableType } from '../utils/types/nullable.type';
 import { User } from '../users/domain/user';
@@ -43,12 +42,6 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   public login(@Body() loginDto: AuthEmailLoginDto): Promise<LoginResponseDto> {
     return this.service.validateLogin(loginDto);
-  }
-
-  @Post('email/register')
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async register(@Body() createUserDto: AuthRegisterLoginDto): Promise<void> {
-    return this.service.register(createUserDto);
   }
 
   @Post('email/confirm')

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,18 +6,11 @@ import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AnonymousStrategy } from './strategies/anonymous.strategy';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
-import { MailModule } from '../mail/mail.module';
 import { SessionModule } from '../session/session.module';
 import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [
-    UsersModule,
-    SessionModule,
-    PassportModule,
-    MailModule,
-    JwtModule.register({}),
-  ],
+  imports: [UsersModule, SessionModule, PassportModule, JwtModule.register({})],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtRefreshStrategy, AnonymousStrategy],
   exports: [AuthService],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -12,7 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import bcrypt from 'bcryptjs';
 import { AuthEmailLoginDto } from './dto/auth-email-login.dto';
 import { AuthUpdateDto } from './dto/auth-update.dto';
-import { AuthRegisterLoginDto } from './dto/auth-register-login.dto';
+import { CreateUserDto } from '../users/dto/create-user.dto';
 import { NullableType } from '../utils/types/nullable.type';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { ConfigService } from '@nestjs/config';
@@ -20,12 +20,15 @@ import { JwtRefreshPayloadType } from './strategies/types/jwt-refresh-payload.ty
 import { JwtPayloadType } from './strategies/types/jwt-payload.type';
 import { UsersService } from '../users/users.service';
 import { AllConfigType } from '../config/config.type';
-import { MailService } from '../mail/mail.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RoleEnum } from '../roles/roles.enum';
 import { Session } from '../session/domain/session';
 import { SessionService } from '../session/session.service';
 import { StatusEnum } from '../statuses/statuses.enum';
 import { User } from '../users/domain/user';
+import { UserRegisteredEvent } from './events/user-registered.event';
+import { ForgotPasswordEvent } from './events/forgot-password.event';
+import { ConfirmNewEmailEvent } from './events/confirm-new-email.event';
 
 @Injectable()
 export class AuthService {
@@ -33,7 +36,7 @@ export class AuthService {
     private jwtService: JwtService,
     private usersService: UsersService,
     private sessionService: SessionService,
-    private mailService: MailService,
+    private eventEmitter: EventEmitter2,
     private configService: ConfigService<AllConfigType>,
   ) {}
 
@@ -97,17 +100,20 @@ export class AuthService {
     };
   }
 
-  async register(dto: AuthRegisterLoginDto): Promise<void> {
-    const user = await this.usersService.create({
-      ...dto,
-      email: dto.email,
-      role: {
-        id: RoleEnum.operator,
+  async register(dto: CreateUserDto, payload?: JwtPayloadType): Promise<User> {
+    const user = await this.usersService.create(
+      {
+        ...dto,
+        email: dto.email,
+        role: dto.role ?? {
+          id: RoleEnum.operator,
+        },
+        status: {
+          id: StatusEnum.inactive,
+        },
       },
-      status: {
-        id: StatusEnum.inactive,
-      },
-    });
+      payload,
+    );
 
     const hash = await this.jwtService.signAsync(
       {
@@ -123,12 +129,12 @@ export class AuthService {
       },
     );
 
-    await this.mailService.userSignUp({
-      to: dto.email,
-      data: {
-        hash,
-      },
-    });
+    this.eventEmitter.emit(
+      'auth.user-registered',
+      new UserRegisteredEvent(dto.email!, hash),
+    );
+
+    return user;
   }
 
   async confirmEmail(hash: string): Promise<void> {
@@ -244,13 +250,10 @@ export class AuthService {
       },
     );
 
-    await this.mailService.forgotPassword({
-      to: email,
-      data: {
-        hash,
-        tokenExpires,
-      },
-    });
+    this.eventEmitter.emit(
+      'auth.forgot-password',
+      new ForgotPasswordEvent(email, hash, tokenExpires),
+    );
   }
 
   async resetPassword(hash: string, password: string): Promise<void> {
@@ -380,12 +383,10 @@ export class AuthService {
         },
       );
 
-      await this.mailService.confirmNewEmail({
-        to: userDto.email,
-        data: {
-          hash,
-        },
-      });
+      this.eventEmitter.emit(
+        'auth.confirm-new-email',
+        new ConfirmNewEmailEvent(userDto.email!, hash),
+      );
     }
 
     delete userDto.email;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -29,6 +29,7 @@ import { User } from '../users/domain/user';
 import { UserRegisteredEvent } from './events/user-registered.event';
 import { ForgotPasswordEvent } from './events/forgot-password.event';
 import { ConfirmNewEmailEvent } from './events/confirm-new-email.event';
+import { AuthEvents } from './events/auth-events.enum';
 
 @Injectable()
 export class AuthService {
@@ -130,7 +131,7 @@ export class AuthService {
     );
 
     this.eventEmitter.emit(
-      'auth.user-registered',
+      AuthEvents.userRegistered,
       new UserRegisteredEvent(dto.email!, hash),
     );
 
@@ -251,7 +252,7 @@ export class AuthService {
     );
 
     this.eventEmitter.emit(
-      'auth.forgot-password',
+      AuthEvents.forgotPassword,
       new ForgotPasswordEvent(email, hash, tokenExpires),
     );
   }
@@ -384,7 +385,7 @@ export class AuthService {
       );
 
       this.eventEmitter.emit(
-        'auth.confirm-new-email',
+        AuthEvents.confirmNewEmail,
         new ConfirmNewEmailEvent(userDto.email!, hash),
       );
     }

--- a/src/auth/dto/auth-register-login.dto.ts
+++ b/src/auth/dto/auth-register-login.dto.ts
@@ -1,7 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, MinLength, IsOptional } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { lowerCaseTransformer } from '../../utils/transformers/lower-case.transformer';
+import { RoleDto } from '../../roles/dto/role.dto';
+import { StatusDto } from '../../statuses/dto/status.dto';
 
 export class AuthRegisterLoginDto {
   @ApiProperty({ example: 'test1@example.com', type: String })
@@ -24,4 +26,14 @@ export class AuthRegisterLoginDto {
   @ApiProperty({ example: '+55123456789' })
   @IsNotEmpty()
   phone: string;
+
+  @ApiPropertyOptional({ type: RoleDto })
+  @IsOptional()
+  @Type(() => RoleDto)
+  role?: RoleDto;
+
+  @ApiPropertyOptional({ type: StatusDto })
+  @IsOptional()
+  @Type(() => StatusDto)
+  status?: StatusDto;
 }

--- a/src/auth/events/auth-events.enum.ts
+++ b/src/auth/events/auth-events.enum.ts
@@ -1,0 +1,5 @@
+export enum AuthEvents {
+  userRegistered = 'auth.user-registered',
+  forgotPassword = 'auth.forgot-password',
+  confirmNewEmail = 'auth.confirm-new-email',
+}

--- a/src/auth/events/confirm-new-email.event.ts
+++ b/src/auth/events/confirm-new-email.event.ts
@@ -1,0 +1,6 @@
+export class ConfirmNewEmailEvent {
+  constructor(
+    public readonly email: string,
+    public readonly hash: string,
+  ) {}
+}

--- a/src/auth/events/forgot-password.event.ts
+++ b/src/auth/events/forgot-password.event.ts
@@ -1,0 +1,7 @@
+export class ForgotPasswordEvent {
+  constructor(
+    public readonly email: string,
+    public readonly hash: string,
+    public readonly tokenExpires: number,
+  ) {}
+}

--- a/src/auth/events/user-registered.event.ts
+++ b/src/auth/events/user-registered.event.ts
@@ -1,0 +1,6 @@
+export class UserRegisteredEvent {
+  constructor(
+    public readonly email: string,
+    public readonly hash: string,
+  ) {}
+}

--- a/src/mail/auth-mail.listener.ts
+++ b/src/mail/auth-mail.listener.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { MailService } from './mail.service';
+import { UserRegisteredEvent } from '../auth/events/user-registered.event';
+import { ForgotPasswordEvent } from '../auth/events/forgot-password.event';
+import { ConfirmNewEmailEvent } from '../auth/events/confirm-new-email.event';
+
+@Injectable()
+export class AuthMailListener {
+  constructor(private readonly mailService: MailService) {}
+
+  @OnEvent('auth.user-registered')
+  async handleUserRegistered(event: UserRegisteredEvent) {
+    await this.mailService.userSignUp({
+      to: event.email,
+      data: { hash: event.hash },
+    });
+  }
+
+  @OnEvent('auth.forgot-password')
+  async handleForgotPassword(event: ForgotPasswordEvent) {
+    await this.mailService.forgotPassword({
+      to: event.email,
+      data: { hash: event.hash, tokenExpires: event.tokenExpires },
+    });
+  }
+
+  @OnEvent('auth.confirm-new-email')
+  async handleConfirmNewEmail(event: ConfirmNewEmailEvent) {
+    await this.mailService.confirmNewEmail({
+      to: event.email,
+      data: { hash: event.hash },
+    });
+  }
+}

--- a/src/mail/auth-mail.listener.ts
+++ b/src/mail/auth-mail.listener.ts
@@ -4,12 +4,13 @@ import { MailService } from './mail.service';
 import { UserRegisteredEvent } from '../auth/events/user-registered.event';
 import { ForgotPasswordEvent } from '../auth/events/forgot-password.event';
 import { ConfirmNewEmailEvent } from '../auth/events/confirm-new-email.event';
+import { AuthEvents } from '../auth/events/auth-events.enum';
 
 @Injectable()
 export class AuthMailListener {
   constructor(private readonly mailService: MailService) {}
 
-  @OnEvent('auth.user-registered')
+  @OnEvent(AuthEvents.userRegistered)
   async handleUserRegistered(event: UserRegisteredEvent) {
     await this.mailService.userSignUp({
       to: event.email,
@@ -17,7 +18,7 @@ export class AuthMailListener {
     });
   }
 
-  @OnEvent('auth.forgot-password')
+  @OnEvent(AuthEvents.forgotPassword)
   async handleForgotPassword(event: ForgotPasswordEvent) {
     await this.mailService.forgotPassword({
       to: event.email,
@@ -25,7 +26,7 @@ export class AuthMailListener {
     });
   }
 
-  @OnEvent('auth.confirm-new-email')
+  @OnEvent(AuthEvents.confirmNewEmail)
   async handleConfirmNewEmail(event: ConfirmNewEmailEvent) {
     await this.mailService.confirmNewEmail({
       to: event.email,

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { MailService } from './mail.service';
 import { MailerModule } from '../mailer/mailer.module';
+import { AuthMailListener } from './auth-mail.listener';
 
 @Module({
   imports: [ConfigModule, MailerModule],
-  providers: [MailService],
+  providers: [MailService, AuthMailListener],
   exports: [MailService],
 })
 export class MailModule {}

--- a/src/modules/dashboard/dashboard-users.controller.ts
+++ b/src/modules/dashboard/dashboard-users.controller.ts
@@ -31,6 +31,7 @@ import { CreateUserDto } from '../../users/dto/create-user.dto';
 import { QueryUserDto } from '../../users/dto/query-user.dto';
 import { UpdateUserDto } from '../../users/dto/update-user.dto';
 import { UsersService } from '../../users/users.service';
+import { AuthService } from '../../auth/auth.service';
 import {
   InfinityPaginationResponse,
   InfinityPaginationResponseDto,
@@ -47,7 +48,10 @@ import { NullableType } from '../../utils/types/nullable.type';
   version: '1',
 })
 export class DashboardUsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
 
   @ApiCreatedResponse({
     type: User,
@@ -61,7 +65,7 @@ export class DashboardUsersController {
     @Body() createProfileDto: CreateUserDto,
     @JwtPayload() payload: JwtPayloadType,
   ): Promise<User> {
-    return this.usersService.create(createProfileDto, payload);
+    return this.authService.register(createProfileDto, payload);
   }
 
   @ApiOkResponse({

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -19,6 +19,7 @@ import { DashboardUsersController } from './dashboard-users.controller';
 import { UsersModule } from '../../users/users.module';
 import { DashboardSpecialistsController } from './dashboard-specialists.controller';
 import { SpecialistsModule } from '../../specialists/specialists.module';
+import { AuthModule } from '../../auth/auth.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SpecialistsModule } from '../../specialists/specialists.module';
     SpeciesModule,
     FileMinioModule,
     UsersModule,
+    AuthModule,
     SpecialistsModule,
   ],
   providers: [ListDashboardSummaryUseCase],


### PR DESCRIPTION
## Summary
- always set `inactive` status on user registration
- remove obsolete `email/register` endpoint
- send email notifications using NestJS EventEmitter for async handling

## Testing
- `npm test` *(fails: no tests found)*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68687024c8188333aa48777b56c3aafc