### PR TITLE
Add Portuguese email templates with unified layout

### DIFF
--- a/src/i18n/pt-BR/common.json
+++ b/src/i18n/pt-BR/common.json
@@ -1,0 +1,4 @@
+{
+  "confirmEmail": "Confirmar e-mail",
+  "resetPassword": "Redefinir senha"
+}

--- a/src/i18n/pt-BR/confirm-email.json
+++ b/src/i18n/pt-BR/confirm-email.json
@@ -1,0 +1,5 @@
+{
+  "text1": "Olá!",
+  "text2": "Você está quase pronto para aproveitar",
+  "text3": "Basta clicar no botão verde abaixo para confirmar seu endereço de e-mail."
+}

--- a/src/i18n/pt-BR/confirm-new-email.json
+++ b/src/i18n/pt-BR/confirm-new-email.json
@@ -1,0 +1,5 @@
+{
+  "text1": "Olá!",
+  "text2": "Confirme seu novo endereço de e-mail.",
+  "text3": "Basta clicar no botão verde abaixo para verificar seu novo endereço."
+}

--- a/src/i18n/pt-BR/reset-password.json
+++ b/src/i18n/pt-BR/reset-password.json
@@ -1,0 +1,6 @@
+{
+  "text1": "Problemas para entrar?",
+  "text2": "Redefinir sua senha é fácil.",
+  "text3": "Basta pressionar o botão abaixo e seguir as instruções. Em pouco tempo você voltará a usar o sistema.",
+  "text4": "Se você não solicitou esta alteração, ignore este e-mail."
+}

--- a/src/mail/mail-templates/activation.hbs
+++ b/src/mail/mail-templates/activation.hbs
@@ -1,33 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=">
-    <title>{{title}}</title>
-</head>
-
-<body style="margin:0;font-family:arial">
-    <table style="border:0;width:100%">
-        <tr style="background:#eeeeee">
-            <td style="padding:20px;color:#808080;text-align:center;font-size:40px;font-weight:600">
-                {{app_name}}
-            </td>
-        </tr>
-        <tr>
-            <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text1}}<br>
-                {{text2}} {{app_name}}.<br>
-                {{text3}}
-            </td>
-        </tr>
-        <tr>
-            <td style="text-align:center">
-                <a href="{{url}}"
-                    style="display:inline-block;padding:20px;background:#00838f;text-decoration:none;color:#ffffff">{{actionTitle}}</a>
-            </td>
-        </tr>
-    </table>
-</body>
-
-</html>
+<tr>
+  <td style="padding:20px;color:#424242;font-size:16px;font-weight:400;">
+    {{text1}}<br>
+    {{text2}} {{app_name}}.<br>
+    {{text3}}
+  </td>
+</tr>
+<tr>
+  <td style="text-align:center;padding-bottom:20px;">
+    <a href="{{url}}" style="display:inline-block;padding:12px 24px;background:#2e7d32;text-decoration:none;color:#ffffff;border-radius:4px;">{{actionTitle}}</a>
+  </td>
+</tr>

--- a/src/mail/mail-templates/confirm-new-email.hbs
+++ b/src/mail/mail-templates/confirm-new-email.hbs
@@ -1,33 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=">
-    <title>{{title}}</title>
-</head>
-
-<body style="margin:0;font-family:arial">
-    <table style="border:0;width:100%">
-        <tr style="background:#eeeeee">
-            <td style="padding:20px;color:#808080;text-align:center;font-size:40px;font-weight:600">
-                {{app_name}}
-            </td>
-        </tr>
-        <tr>
-            <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text1}}<br>
-                {{text2}}<br>
-                {{text3}}
-            </td>
-        </tr>
-        <tr>
-            <td style="text-align:center">
-                <a href="{{url}}"
-                    style="display:inline-block;padding:20px;background:#00838f;text-decoration:none;color:#ffffff">{{actionTitle}}</a>
-            </td>
-        </tr>
-    </table>
-</body>
-
-</html>
+<tr>
+  <td style="padding:20px;color:#424242;font-size:16px;font-weight:400;">
+    {{text1}}<br>
+    {{text2}}<br>
+    {{text3}}
+  </td>
+</tr>
+<tr>
+  <td style="text-align:center;padding-bottom:20px;">
+    <a href="{{url}}" style="display:inline-block;padding:12px 24px;background:#2e7d32;text-decoration:none;color:#ffffff;border-radius:4px;">{{actionTitle}}</a>
+  </td>
+</tr>

--- a/src/mail/mail-templates/layout.hbs
+++ b/src/mail/mail-templates/layout.hbs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="{{lang}}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}}</title>
+</head>
+<body style="margin:0;font-family:Arial, sans-serif;background:#f5f5f5;">
+  <table style="border:0;width:100%;max-width:600px;margin:auto;background:#ffffff;">
+    <tr style="background:#2e7d32;color:#ffffff;">
+      <td style="padding:20px;text-align:center;">
+        {{#if logo}}
+        <img src="{{logo}}" alt="UFRA" style="max-height:60px;">
+        {{else}}
+        <span style="font-size:32px;font-weight:600;">{{app_name}}</span>
+        {{/if}}
+      </td>
+    </tr>
+    {{{body}}}
+  </table>
+</body>
+</html>

--- a/src/mail/mail-templates/reset-password.hbs
+++ b/src/mail/mail-templates/reset-password.hbs
@@ -1,38 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=">
-    <title>{{title}}</title>
-</head>
-
-<body style="margin:0;font-family:arial">
-    <table style="border:0;width:100%">
-        <tr style="background:#eeeeee">
-            <td style="padding:20px;color:#808080;text-align:center;font-size:40px;font-weight:600">
-                {{app_name}}
-            </td>
-        </tr>
-        <tr>
-            <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text1}}<br>
-                {{text2}}<br>
-                {{text3}}
-            </td>
-        </tr>
-        <tr>
-            <td style="text-align:center">
-                <a href="{{url}}"
-                    style="display:inline-block;padding:20px;background:#00838f;text-decoration:none;color:#ffffff">{{actionTitle}}</a>
-            </td>
-        </tr>
-        <tr>
-            <td style="padding:20px;color:#808080;font-size:16px;font-weight:100">
-                {{text4}}
-            </td>
-        </tr>
-    </table>
-</body>
-
-</html>
+<tr>
+  <td style="padding:20px;color:#424242;font-size:16px;font-weight:400;">
+    {{text1}}<br>
+    {{text2}}<br>
+    {{text3}}
+  </td>
+</tr>
+<tr>
+  <td style="text-align:center;padding-bottom:20px;">
+    <a href="{{url}}" style="display:inline-block;padding:12px 24px;background:#2e7d32;text-decoration:none;color:#ffffff;border-radius:4px;">{{actionTitle}}</a>
+  </td>
+</tr>
+<tr>
+  <td style="padding:20px;color:#424242;font-size:16px;font-weight:400;">
+    {{text4}}
+  </td>
+</tr>


### PR DESCRIPTION
## Summary
- add Portuguese i18n files for email content
- create reusable Handlebars layout with UFRA logo
- restyle activation, confirm-new-email and reset-password templates
- embed layout use in `MailerService`

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6869763f9150833399a4e1a3e978c24c