### PR TITLE
Enable build checks for pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,27 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+
   build-and-push:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -98,6 +116,7 @@ jobs:
           cache-to: type=inline
 
   deploy:
+    if: github.event_name == 'push'
     needs: build-and-push
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- run the Docker build when a PR is opened
- skip pushing and deployment unless on `main`

## Testing
- `npm ci`
- `npm test -- --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68728bb19d948333882c4d4649408a5c